### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/PSpec.pm6
+++ b/lib/PSpec.pm6
@@ -1,7 +1,7 @@
 use v6;
 use Test;
 
-module PSpec:ver<4.0.0>:auth<http://huri.net/>;
+unit module PSpec:ver<4.0.0>:auth<http://huri.net/>;
 
 ## Perform a block of code x number of times.
 multi sub infix:<times> (Int $num, &closure) is export 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.