### PR TITLE
Travis CI Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: perl6
+
+perl6:
+    - latest
+    - 2016.01
+
+script:
+    - PERL6LIB=lib prove -v -r --exec=perl6 t/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PSpec -- RSpec for Perl 6 [![Build Status](https://travis-ci.org/tbrownaw/PSpec.svg?branch=master)](https://travis-ci.org/tbrownaw/PSpec)
+# PSpec -- RSpec for Perl 6 [![Build Status](https://travis-ci.org/supernovus/PSpec.svg?branch=master)](https://travis-ci.org/supernovus/PSpec)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PSpec -- RSpec for Perl 6
+# PSpec -- RSpec for Perl 6 [![Build Status](https://travis-ci.org/tbrownaw/PSpec.svg?branch=master)](https://travis-ci.org/tbrownaw/PSpec)
 
 ## Introduction
 


### PR DESCRIPTION
Set up Travis CI config file and status badge. The badge in the readme is pointed at your repo rather than my fork, so it won't work until you go to https://travis-ci.org/auth and activate it.